### PR TITLE
add an async loop to speed up the pollers

### DIFF
--- a/internal/services/postgres/postgresql_flexible_server_firewall_rules_resource.go
+++ b/internal/services/postgres/postgresql_flexible_server_firewall_rules_resource.go
@@ -288,12 +288,19 @@ func resourcePostgresqlFlexibleServerFirewallRulesDelete(d *pluginsdk.ResourceDa
 		pollers = append(pollers, poller.Poller)
 	}
 
+	wg := sync.WaitGroup{}
+
 	for _, poller := range pollers {
-		if err := poller.PollUntilDone(ctx); err != nil {
-			return fmt.Errorf("polling after Delete: %+v", err)
-		}
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if err := poller.PollUntilDone(ctx); err != nil {
+				fmt.Errorf("polling after Delete: %+v", err)
+			}
+		}()
 	}
 
+	wg.Wait()
 	return nil
 }
 

--- a/internal/services/postgres/postgresql_flexible_server_firewall_rules_resource.go
+++ b/internal/services/postgres/postgresql_flexible_server_firewall_rules_resource.go
@@ -283,7 +283,7 @@ func resourcePostgresqlFlexibleServerFirewallRulesDelete(d *pluginsdk.ResourceDa
 	for _, rule := range listFirewallRulesResult.Items {
 		poller, err := firewall_rules_client.Delete(ctx, firewallrules.NewFirewallRuleID(subscriptionId, flexibleServerId.ResourceGroupName, flexibleServerId.FlexibleServerName, *rule.Name))
 		if err != nil {
-			return fmt.Errorf("deleting %q: %+v", rule.Name, err)
+			return fmt.Errorf("deleting %q: %+v", *rule.Name, err)
 		}
 		pollers = append(pollers, poller.Poller)
 	}

--- a/internal/services/postgres/postgresql_flexible_server_firewall_rules_resource_test.go
+++ b/internal/services/postgres/postgresql_flexible_server_firewall_rules_resource_test.go
@@ -1,0 +1,134 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package postgres_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/go-azure-sdk/resource-manager/postgresql/2022-12-01/firewallrules"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+	"github.com/hashicorp/terraform-provider-azurerm/utils"
+)
+
+type PostgresqlFlexibleServerFirewallRulesResource struct{}
+
+func TestAccPostgresqlFlexibleServerFirewallRules_basic(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_postgresql_flexible_server_firewall_rules", "test")
+	r := PostgresqlFlexibleServerFirewallRulesResource{}
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccPostgresqlFlexibleServerFirewallRules_requiresImport(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_postgresql_flexible_server_firewall_rules", "test")
+	r := PostgresqlFlexibleServerFirewallRulesResource{}
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.RequiresImportErrorStep(r.requiresImport),
+	})
+}
+
+func TestAccPostgresqlFlexibleServerFirewallRules_update(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_postgresql_flexible_server_firewall_rules", "test")
+	r := PostgresqlFlexibleServerFirewallRulesResource{}
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.update(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func (PostgresqlFlexibleServerFirewallRulesResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
+	id, err := firewallrules.ParseFirewallRuleID(state.ID)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := clients.Postgres.FlexibleServerFirewallRuleClient.Get(ctx, *id)
+	if err != nil {
+		return nil, fmt.Errorf("retrieving %s: %+v", id, err)
+	}
+
+	return utils.Bool(resp.Model != nil), nil
+}
+
+func (PostgresqlFlexibleServerFirewallRulesResource) basic(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_postgresql_flexible_server_firewall_rules" "test" {
+  server_id        = azurerm_postgresql_flexible_server.test.id
+  firewall_rule {
+	name             = "acctest-FSFR-%d"
+	start_ip_address = "122.122.0.0"
+	end_ip_address   = "122.122.0.0"
+  }
+}
+`, PostgresqlFlexibleServerResource{}.basic(data), data.RandomInteger)
+}
+
+func (r PostgresqlFlexibleServerFirewallRulesResource) requiresImport(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_postgresql_flexible_server_firewall_rules" "import" {
+  server_id        = azurerm_postgresql_flexible_server_firewall_rules.test.server_id
+  firewall_rule {
+	name             = "acctest-FSFR"
+	start_ip_address = "122.122.0.0"
+	end_ip_address   = "122.122.0.0"
+  }
+}
+`, r.basic(data))
+}
+
+func (r PostgresqlFlexibleServerFirewallRulesResource) update(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_postgresql_flexible_server_firewall_rules" "test" {
+	server_id        = azurerm_postgresql_flexible_server.test.id
+		firewall_rule {
+		name             = "acctest-FSFR-%d"
+		start_ip_address = "123.0.0.0"
+		end_ip_address   = "123.0.0.0"
+	}
+}
+`, PostgresqlFlexibleServerResource{}.basic(data), data.RandomInteger)
+}


### PR DESCRIPTION
Testing out some changes to make the polling a bit faster.

With a config adding three firewall rules like so:
```
locals {
  firewall_rules = [
{
    name = "test-rule-1"
    end_ip_address = "x.x.x.x"
    start_ip_address = "x.x.x.x"
  },{
        name = "test-rule-2"
    end_ip_address = "x.x.x.y"
    start_ip_address = "x.x.x.y"
  },{
        name = "test-rule-3"
    end_ip_address = "x.x.x.z"
    start_ip_address = "x.x.x.z"
  }
  ]
}

resource "azurerm_postgresql_flexible_server_firewall_rules" "test-fw" {
  server_id = data.azurerm_postgresql_flexible_server.example.id
  dynamic "firewall_rule" {
    for_each = local.firewall_rules
    content {
      name = firewall_rule.value.name
      start_ip_address = firewall_rule.value.start_ip_address
      end_ip_address = firewall_rule.value.end_ip_address
    }
  }

}
```

Without this change, adding them took three minutes:

```
azurerm_postgresql_flexible_server_firewall_rules.test-fw: Creating...
azurerm_postgresql_flexible_server_firewall_rules.test-fw: Still creating... [10s elapsed]
azurerm_postgresql_flexible_server_firewall_rules.test-fw: Still creating... [20s elapsed]
azurerm_postgresql_flexible_server_firewall_rules.test-fw: Still creating... [30s elapsed]
azurerm_postgresql_flexible_server_firewall_rules.test-fw: Still creating... [40s elapsed]
azurerm_postgresql_flexible_server_firewall_rules.test-fw: Still creating... [50s elapsed]
azurerm_postgresql_flexible_server_firewall_rules.test-fw: Still creating... [1m0s elapsed]
azurerm_postgresql_flexible_server_firewall_rules.test-fw: Still creating... [1m10s elapsed]
azurerm_postgresql_flexible_server_firewall_rules.test-fw: Still creating... [1m20s elapsed]
azurerm_postgresql_flexible_server_firewall_rules.test-fw: Still creating... [1m30s elapsed]
azurerm_postgresql_flexible_server_firewall_rules.test-fw: Still creating... [1m40s elapsed]
azurerm_postgresql_flexible_server_firewall_rules.test-fw: Still creating... [1m50s elapsed]
azurerm_postgresql_flexible_server_firewall_rules.test-fw: Still creating... [2m0s elapsed]
azurerm_postgresql_flexible_server_firewall_rules.test-fw: Still creating... [2m10s elapsed]
azurerm_postgresql_flexible_server_firewall_rules.test-fw: Still creating... [2m20s elapsed]
azurerm_postgresql_flexible_server_firewall_rules.test-fw: Still creating... [2m30s elapsed]
azurerm_postgresql_flexible_server_firewall_rules.test-fw: Still creating... [2m40s elapsed]
azurerm_postgresql_flexible_server_firewall_rules.test-fw: Still creating... [2m50s elapsed]
azurerm_postgresql_flexible_server_firewall_rules.test-fw: Still creating... [3m0s elapsed]
azurerm_postgresql_flexible_server_firewall_rules.test-fw: Creation complete after 3m5s ]
```

Adding this change in gets that same config down to one minute:
```
azurerm_postgresql_flexible_server_firewall_rules.test-fw: Creating...
azurerm_postgresql_flexible_server_firewall_rules.test-fw: Still creating... [10s elapsed]
azurerm_postgresql_flexible_server_firewall_rules.test-fw: Still creating... [20s elapsed]
azurerm_postgresql_flexible_server_firewall_rules.test-fw: Still creating... [30s elapsed]
azurerm_postgresql_flexible_server_firewall_rules.test-fw: Still creating... [40s elapsed]
azurerm_postgresql_flexible_server_firewall_rules.test-fw: Still creating... [50s elapsed]
azurerm_postgresql_flexible_server_firewall_rules.test-fw: Still creating... [1m0s elapsed]
azurerm_postgresql_flexible_server_firewall_rules.test-fw: Creation complete after 1m3s
```

Again, there might be a better way to do this, but it does seem positive. Let me know that you think!